### PR TITLE
fix: use AppContext.BaseDirectory for standalone app

### DIFF
--- a/src/dotenv.net/DotEnv.cs
+++ b/src/dotenv.net/DotEnv.cs
@@ -59,8 +59,7 @@ namespace dotenv.net
         /// <returns>States whether or not the operation succeeded</returns>
         public static bool AutoConfig(int levelsToSearch = 3)
         {
-            var assembly = new FileInfo(Assembly.GetExecutingAssembly().Location);
-            var currentDirectory = assembly.Directory;
+            var currentDirectory = new DirectoryInfo(AppContext.BaseDirectory);
 
             for (;
                 currentDirectory != null && levelsToSearch > 0;


### PR DESCRIPTION
With `.NET 5.0`, when compiling a standalone console app, it seems that `Assembly.GetExecutingAssembly()` is not available. The compiler/warning suggested to use `AppContext.BaseDirectory`

This PR **should** fix the issue (I can't run tests; I will rely on CI here)