### PR TITLE
Removed unused reference to System.Memory package

### DIFF
--- a/src/dotenv.net/dotenv.net.csproj
+++ b/src/dotenv.net/dotenv.net.csproj
@@ -24,8 +24,4 @@
     <TargetFrameworks>net5.0;net5.0-windows;netstandard1.6;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Title>dotenv.net</Title>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.4" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Removed unused reference to `System.Memory` in the project's .csproj (`System.Memory` takes about 200 KB of memory)