### PR TITLE
feature: enabled multi-line parsing of env files

### DIFF
--- a/src/dotenv.net/Parser.cs
+++ b/src/dotenv.net/Parser.cs
@@ -1,75 +1,89 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace dotenv.net
 {
     internal static class Parser
     {
-        private static readonly char[] SingleQuote = {'\''};
-        private static readonly char[] DoubleQuotes = {'"'};
-        
-        internal static ReadOnlySpan<KeyValuePair<string, string>> Parse(ReadOnlySpan<string> dotEnvRows,
-            bool shouldTrimValue)
+        private const string SingleQuote = "'";
+        private const string DoubleQuotes = "\"";
+
+        internal static ReadOnlySpan<KeyValuePair<string, string>> Parse(ReadOnlySpan<string> rawEnvRows,
+            bool trimValues)
         {
-            var validEntries = new List<KeyValuePair<string, string>>();
+            var keyValuePairs = new List<KeyValuePair<string, string>>();
 
-            foreach (var dotEnvRow in dotEnvRows)
+            for (var i = 0; i < rawEnvRows.Length; i++)
             {
-                var row = new ReadOnlySpan<char>(dotEnvRow.TrimStart().ToCharArray());
+                var rawEnvRow = rawEnvRows[i];
 
-                if (row.IsEmpty)
-                    continue;
+                if(rawEnvRow.StartsWith("#")) continue;
 
-                if (row.IsComment())
-                    continue;
+                if (rawEnvRow.Contains("=\""))
+                {
+                    var key = rawEnvRow.Substring(0, rawEnvRow.IndexOf("=\"", StringComparison.Ordinal));
+                    var valueStringBuilder = new StringBuilder();
+                    valueStringBuilder.Append(rawEnvRow.Substring(rawEnvRow.IndexOf("=\"", StringComparison.Ordinal) + 2));
 
-                if (row.HasNoKey(out var index))
-                    continue;
+                    while (!rawEnvRow.EndsWith("\""))
+                    {
+                        i++;
+                        if (i >= rawEnvRows.Length)
+                        {
+                            break;
+                        }
+                        rawEnvRow = rawEnvRows[i];
+                        valueStringBuilder.Append(rawEnvRow);
+                    }
+                    //Remove last "
+                    valueStringBuilder.Remove(valueStringBuilder.Length - 1, 1);
 
-                var key = row.Key(index);
-                var value = row.Value(index, shouldTrimValue);
-                validEntries.Add(new KeyValuePair<string, string>(key, value));
+                    var value = valueStringBuilder.ToString();
+                    if (trimValues)
+                    {
+                        value = value.Trim();
+                    }
+
+                    keyValuePairs.Add(new KeyValuePair<string, string>(key, value));
+                }
+                else
+                {
+                    //Check that line is not empty
+                    var rawEnvEmpty = rawEnvRow.Trim();
+                    if(string.IsNullOrEmpty(rawEnvEmpty)) continue;
+
+                    // Regular key-value pair
+                    var keyValue = rawEnvRow.Split(new[] { '=' }, 2);
+
+                    var key = keyValue[0].Trim();
+                    var value = keyValue[1];
+
+                    if(string.IsNullOrEmpty(key)) continue;
+
+                    if (IsQuoted(value))
+                    {
+                        value = StripQuotes(value);
+                    }
+
+                    if (trimValues)
+                    {
+                        value = value.Trim();
+                    }
+
+                    keyValuePairs.Add(new KeyValuePair<string, string>(key, value));
+                }
             }
 
-            return new ReadOnlySpan<KeyValuePair<string, string>>(validEntries.ToArray());
+            return keyValuePairs.ToArray();
         }
 
-        private static bool IsComment(this ReadOnlySpan<char> row) => row[0] == '#';
+        private static bool IsQuoted(string value) => (value.StartsWith(SingleQuote) && value.EndsWith(SingleQuote))
+                                                                     || (value.StartsWith(DoubleQuotes) && value.EndsWith(DoubleQuotes));
 
-        private static bool HasNoKey(this ReadOnlySpan<char> row, out int index)
+        private static string StripQuotes(string value)
         {
-            index = row.IndexOf('=');
-            return index <= 0;
-        }
-
-        private static bool IsQuoted(this ReadOnlySpan<char> row) => (row.StartsWith(SingleQuote) && row.EndsWith(SingleQuote))
-                                                                     || (row.StartsWith(DoubleQuotes) && row.EndsWith(DoubleQuotes));
-
-        private static ReadOnlySpan<char> StripQuotes(this ReadOnlySpan<char> row) => row.Trim('\'').Trim('\"');
-
-        private static string Key(this ReadOnlySpan<char> row, int index)
-        {
-            var untrimmedKey = row.Slice(0, index);
-            return untrimmedKey.Trim().ToString();
-        }
-
-        private static string Value(this ReadOnlySpan<char> row, int index, bool trimValue)
-        {
-            var value = row.Slice(index + 1);
-
-            // handle quoted values
-            if (value.IsQuoted())
-            {
-                value = value.StripQuotes();
-            }
-
-            // trim output if requested
-            if (trimValue)
-            {
-                value = value.Trim();
-            }
-
-            return value.ToString();
+            return value.Substring(1, value.Length - 2);
         }
     }
 }

--- a/src/dotenv.net/Utilities/Helpers.cs
+++ b/src/dotenv.net/Utilities/Helpers.cs
@@ -7,7 +7,7 @@ namespace dotenv.net.Utilities
 {
     internal static class Helpers
     {
- private static ReadOnlySpan<KeyValuePair<string, string>> ReadAndParse(string envFilePath,
+        private static ReadOnlySpan<KeyValuePair<string, string>> ReadAndParse(string envFilePath,
             bool ignoreExceptions, Encoding encoding, bool trimValues)
         {
             var rawEnvRows = Reader.Read(envFilePath, ignoreExceptions, encoding);
@@ -17,68 +17,7 @@ namespace dotenv.net.Utilities
                 return ReadOnlySpan<KeyValuePair<string, string>>.Empty;
             }
 
-            return ParseForMultilines(rawEnvRows, trimValues);
-        }
-
-        /// <summary>
-        /// Parses potential multi-line values, surrounded by quotation marks.
-        /// </summary>
-        /// <param name="rawEnvRows">Unedited rows from the env file.</param>
-        /// <param name="trimValues">Whether a line should be trimmed or not.</param>
-        /// <returns>KeyValuePairs, whose multi-line values were properly merged into a single value each.</returns>
-        private static ReadOnlySpan<KeyValuePair<string, string>> ParseForMultilines(ReadOnlySpan<string> rawEnvRows, bool trimValues)
-        {
-            var keyValuePairs = new List<KeyValuePair<string, string>>();
-
-            for (var i = 0; i < rawEnvRows.Length; i++)
-            {
-                var rawEnvRow = rawEnvRows[i];
-
-                if (rawEnvRow.Contains("=\""))
-                {
-                    var key = rawEnvRow.Substring(0, rawEnvRow.IndexOf("=\"", StringComparison.Ordinal));
-                    var valueStringBuilder = new StringBuilder();
-                    valueStringBuilder.Append(rawEnvRow.Substring(rawEnvRow.IndexOf("=\"", StringComparison.Ordinal) + 2));
-
-                    while (!rawEnvRow.EndsWith("\""))
-                    {
-                        i++;
-                        if (i >= rawEnvRows.Length)
-                        {
-                            break;
-                        }
-                        rawEnvRow = rawEnvRows[i];
-                        valueStringBuilder.Append(rawEnvRow);
-                    }
-                    //Remove last "
-                    valueStringBuilder.Remove(valueStringBuilder.Length - 1, 1);
-
-                    var value = valueStringBuilder.ToString();
-                    if (trimValues)
-                    {
-                        value = value.Trim();
-                    }
-
-                    keyValuePairs.Add(new KeyValuePair<string, string>(key, value));
-                }
-                else
-                {
-                    // Regular key-value pair
-                    var keyValue = rawEnvRow.Split(new[] { '=' }, 2);
-
-                    var key = keyValue[0];
-                    var value = keyValue[1];
-
-                    if (trimValues)
-                    {
-                        value = value.Trim();
-                    }
-
-                    keyValuePairs.Add(new KeyValuePair<string, string>(key, value));
-                }
-            }
-
-            return keyValuePairs.ToArray();
+            return Parser.Parse(rawEnvRows, trimValues);
         }
 
         internal static IDictionary<string, string> ReadAndReturn(DotEnvOptions options)

--- a/tests/dotenv.net.Tests/DotEnv.Fluent.Tests.cs
+++ b/tests/dotenv.net.Tests/DotEnv.Fluent.Tests.cs
@@ -12,6 +12,7 @@ namespace dotenv.net.Tests
         private const string WhitespacesEnvFileName = "whitespaces.env";
         private const string NonExistentEnvFileName = "non-existent.env";
         private const string QuotationsEnvFileName = "quotations.env";
+        private const string MultiLinesEnvFileName = "multi-lines.env";
         private const string AsciiEnvFileName = "ascii.env";
         private const string GenericEnvFileName = "generic.env";
         private const string IncompleteEnvFileName = "incomplete.env";
@@ -52,7 +53,7 @@ namespace dotenv.net.Tests
             EnvReader.GetStringValue("DB_DATABASE")
                 .Should()
                 .Be("laravel");
-            
+
             DotEnv.Fluent()
                 .WithEnvFiles(WhitespacesEnvFileName)
                 .WithoutTrimValues()
@@ -67,7 +68,7 @@ namespace dotenv.net.Tests
         public void ConfigShouldLoadEnvWithExistingVarOverwriteOptions()
         {
             Environment.SetEnvironmentVariable("Generic", "Existing");
-            
+
             DotEnv.Fluent()
                 .WithEnvFiles(GenericEnvFileName)
                 .WithoutOverwriteExistingVars()
@@ -76,7 +77,7 @@ namespace dotenv.net.Tests
             EnvReader.GetStringValue("Generic")
                 .Should()
                 .Be("Existing");
-            
+
             DotEnv.Fluent()
                 .WithEnvFiles(GenericEnvFileName)
                 .WithOverwriteExistingVars()
@@ -97,7 +98,7 @@ namespace dotenv.net.Tests
 
             action.Should()
                 .ThrowExactly<FileNotFoundException>();
-            
+
             action = () => DotEnv.Fluent()
                 .WithProbeForEnv(5)
                 .WithExceptions()
@@ -125,6 +126,25 @@ namespace dotenv.net.Tests
             EnvReader.GetStringValue("SINGLE_QUOTES")
                 .Should()
                 .Be("single");
+        }
+
+        [Fact]
+        public void ConfigLoadsMultilineEnvs()
+        {
+            DotEnv.Fluent()
+                .WithEnvFiles(MultiLinesEnvFileName)
+                .WithTrimValues()
+                .Load();
+
+            EnvReader.GetStringValue("DOUBLE_QUOTE")
+                .Should()
+                .Be("double");
+            EnvReader.GetStringValue("DOUBLE_QUOTE_MULTI_LINE")
+                .Should()
+                .Be("doubler");
+            EnvReader.GetStringValue("DOUBLE_QUOTE_EVEN_MORE_LINES")
+                .Should()
+                .Be("doublest");
         }
 
         [Fact]

--- a/tests/dotenv.net.Tests/multi-lines.env
+++ b/tests/dotenv.net.Tests/multi-lines.env
@@ -1,0 +1,8 @@
+DOUBLE_QUOTE="double"
+DOUBLE_QUOTE_MULTI_LINE="dou
+bler"
+DOUBLE_QUOTE_EVEN_MORE_LINES="dou
+
+b
+
+lest"


### PR DESCRIPTION
With this PR it should be possible to read an .env variable from a file with multiple lines.

One minor issue for the tests:
> I can't seem to get the EnvReader to find the new env file I created for the tests. Would be nice if you could take a look and merge this in the next couple of days.