### PR TITLE
feature: Added support for multi-line variables separated by dots

### DIFF
--- a/src/dotenv.net/Parser.cs
+++ b/src/dotenv.net/Parser.cs
@@ -10,7 +10,7 @@ internal static class Parser
     private const string SingleQuote = "'";
     private const string DoubleQuotes = "\"";
 
-    private static readonly Regex IsQuotedLineStart = new("^[a-zA-Z0-9_ ]+=\\s*\".*$", RegexOptions.Compiled);
+    private static readonly Regex IsQuotedLineStart = new("^[a-zA-Z0-9_ .-]+=\\s*\".*$", RegexOptions.Compiled);
     private static readonly Regex IsQuotedLineEnd = new("(?<!\\\\)\"\\s*$", RegexOptions.Compiled);
 
     internal static ReadOnlySpan<KeyValuePair<string, string>> Parse(ReadOnlySpan<string> rawEnvRows,

--- a/src/dotenv.net/dotenv.net.csproj
+++ b/src/dotenv.net/dotenv.net.csproj
@@ -12,12 +12,12 @@
     <RepositoryUrl>https://github.com/bolorundurowb/dotenv.net</RepositoryUrl>
     <LangVersion>default</LangVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageVersion>3.2.0</PackageVersion>
+    <PackageVersion>3.2.1</PackageVersion>
     <RepositoryType>git</RepositoryType>
     <PackageTags>dotnet, environment, variables, env, dotenv, net core, autofac</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>3.2.0</AssemblyVersion>
-    <FileVersion>3.2.0</FileVersion>
+    <AssemblyVersion>3.2.1</AssemblyVersion>
+    <FileVersion>3.2.1</FileVersion>
     <NeutralLanguage>en-NG</NeutralLanguage>
     <TargetFrameworks>netstandard1.6;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Title>dotenv.net</Title>

--- a/tests/dotenv.net.Tests/DotEnv.Fluent.Tests.cs
+++ b/tests/dotenv.net.Tests/DotEnv.Fluent.Tests.cs
@@ -148,6 +148,9 @@ public class DotEnvFluentTests
         EnvReader.GetStringValue("DOUBLE_QUOTE_WHITESPACE_LINES")
             .Should()
             .Be($"dou{Environment.NewLine}{Environment.NewLine}b{Environment.NewLine}{Environment.NewLine}lest");
+        EnvReader.GetStringValue("DOUBLE_QUOTE.WITH_DOTS")
+            .Should()
+            .Be($"dou{Environment.NewLine}{Environment.NewLine}b{Environment.NewLine}{Environment.NewLine}le{Environment.NewLine}dots");
         EnvReader.GetStringValue("DOUBLE_QUOTE_NO_CLOSE")
             .Should()
             .Be($"\"dou{Environment.NewLine}{Environment.NewLine}b{Environment.NewLine}{Environment.NewLine}lest the more");

--- a/tests/dotenv.net.Tests/multi-lines.env
+++ b/tests/dotenv.net.Tests/multi-lines.env
@@ -10,7 +10,13 @@ DOUBLE_QUOTE_WHITESPACE_LINES =  "dou
 
 b
 
-lest"  
+lest"
+DOUBLE_QUOTE.WITH_DOTS =  "dou
+
+b
+
+le
+dots"
 DOUBLE_QUOTE_NO_CLOSE =  "dou
 
 b


### PR DESCRIPTION
Without this, a variable separated by a dot is not considered a multi line variable and instead will only parse the line after the equals sign.