### PR TITLE
feat: Add tests to proof configuration syntax usability

### DIFF
--- a/tests/dotenv.net.Tests/DotEnv.Tests.cs
+++ b/tests/dotenv.net.Tests/DotEnv.Tests.cs
@@ -122,4 +122,62 @@ public class DotEnvTests
             .Should()
             .Be("world");
     }
+
+    [Fact]
+    public void Should_Parse_Key_With_Colon_Correctly_Using_Read()
+    {
+        // Arrange
+        var envFiles = new[] { "appsettings-oidc-config.env" };
+
+        // Act
+        var result = new DotEnvOptions()
+             .WithEnvFiles(envFiles)
+            .Read();
+
+        // Assert
+        result.ContainsKey("OidcAuthentication:ClientId")
+            .Should()
+            .BeTrue();
+
+        result["OidcAuthentication:ClientId"]
+            .Should()
+            .Be("your-client-id");
+
+        result.ContainsKey("OidcAuthentication:ClientSecret")
+            .Should()
+            .BeTrue();
+
+        result["OidcAuthentication:ClientSecret"]
+            .Should()
+            .Be("your-client-secret");
+    }
+
+    [Fact]
+    public void Should_Parse_Key_With_Colon_Correctly_And_Load_To_Environment() // this is failing because colones are not supported in environment variable names on Windows. TODO: Evaluate to add a extension or Helper to enable dotenv usage in hostbuilder IConfigurationBuilder?
+    {
+        // Arrange
+        var envFiles = new[] { "appsettings-oidc-config.env" };
+
+        // Act
+        new DotEnvOptions()
+            .WithEnvFiles(envFiles) 
+            .WithProbeForEnv()
+            .WithExceptions()
+            .Load();
+
+        // Assert
+        EnvReader.TryGetStringValue("OidcAuthentication:ClientId", out var value)
+            .Should()
+            .BeTrue();
+
+        value.Should()
+            .Be("your-client-id");
+
+        EnvReader.TryGetStringValue("OidcAuthentication:ClientSecret", out value)
+            .Should()
+            .BeTrue();
+
+        value.Should()
+            .Be("your-client-secret");
+    }
 }

--- a/tests/dotenv.net.Tests/DotEnv.Tests.cs
+++ b/tests/dotenv.net.Tests/DotEnv.Tests.cs
@@ -151,33 +151,33 @@ public class DotEnvTests
             .Should()
             .Be("your-client-secret");
     }
+// TODO: Uncomment if Loading Configuration Syntax get's correctly loaded via Envrionment Variables and returned
+    // [Fact]
+    // public void Should_Parse_Key_With_Colon_Correctly_And_Load_To_Environment() // this is failing because colones are not supported in environment variable names on Windows. TODO: Evaluate to add a extension or Helper to enable dotenv usage in hostbuilder IConfigurationBuilder?
+    // {
+    //     // Arrange
+    //     var envFiles = new[] { "appsettings-oidc-config.env" };
 
-    [Fact]
-    public void Should_Parse_Key_With_Colon_Correctly_And_Load_To_Environment() // this is failing because colones are not supported in environment variable names on Windows. TODO: Evaluate to add a extension or Helper to enable dotenv usage in hostbuilder IConfigurationBuilder?
-    {
-        // Arrange
-        var envFiles = new[] { "appsettings-oidc-config.env" };
+    //     // Act
+    //     new DotEnvOptions()
+    //         .WithEnvFiles(envFiles) 
+    //         .WithProbeForEnv()
+    //         .WithExceptions()
+    //         .Load();
 
-        // Act
-        new DotEnvOptions()
-            .WithEnvFiles(envFiles) 
-            .WithProbeForEnv()
-            .WithExceptions()
-            .Load();
+    //     // Assert
+    //     EnvReader.TryGetStringValue("OidcAuthentication:ClientId", out var value)
+    //         .Should()
+    //         .BeTrue();
 
-        // Assert
-        EnvReader.TryGetStringValue("OidcAuthentication:ClientId", out var value)
-            .Should()
-            .BeTrue();
+    //     value.Should()
+    //         .Be("your-client-id");
 
-        value.Should()
-            .Be("your-client-id");
+    //     EnvReader.TryGetStringValue("OidcAuthentication:ClientSecret", out value)
+    //         .Should()
+    //         .BeTrue();
 
-        EnvReader.TryGetStringValue("OidcAuthentication:ClientSecret", out value)
-            .Should()
-            .BeTrue();
-
-        value.Should()
-            .Be("your-client-secret");
-    }
+    //     value.Should()
+    //         .Be("your-client-secret");
+    // }
 }

--- a/tests/dotenv.net.Tests/appsettings-oidc-config.env
+++ b/tests/dotenv.net.Tests/appsettings-oidc-config.env
@@ -1,0 +1,2 @@
+OidcAuthentication:ClientId=your-client-id
+OidcAuthentication:ClientSecret=your-client-secret

--- a/tests/dotenv.net.Tests/dotenv.net.Tests.csproj
+++ b/tests/dotenv.net.Tests/dotenv.net.Tests.csproj
@@ -26,6 +26,9 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <None Update="appsettings-oidc-config.env">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="ascii.env">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Using the `.Read()` Method with configuration colone syntax passes the test, but using Load() does not, because Windows EnvironmentVariables are not allowing colone usage.

Please evaluate, to add a extension method for IConfigurationBuilder to pass in the appropriate key value pairs