### PR TITLE
#56 | fix exception path in probe for env

### DIFF
--- a/src/dotenv.net.Tests/DotEnvOptionsTests.cs
+++ b/src/dotenv.net.Tests/DotEnvOptionsTests.cs
@@ -71,14 +71,6 @@ public class DotEnvOptionsTests
         options.ProbeLevelsToSearch.ShouldBe(DotEnvOptions.DefaultProbeAscendLimit);
     }
 
-    [Fact]
-    public void WithDefaultEncoding_ShouldResetToUtf8()
-    {
-        var options = new DotEnvOptions().WithEncoding(Encoding.ASCII);
-        options.WithDefaultEncoding();
-        options.Encoding.ShouldBe(Encoding.UTF8);
-    }
-
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/src/dotenv.net.Tests/DotEnvOptionsTests.cs
+++ b/src/dotenv.net.Tests/DotEnvOptionsTests.cs
@@ -31,6 +31,21 @@ public class DotEnvOptionsTests
     }
 
     [Fact]
+    public void Constructor_WithProbeForEnvAndNoLevels_ShouldSetDefaults()
+    {
+        var options = new DotEnvOptions(probeForEnv: true, envFilePaths: null);
+        options.ProbeForEnv.ShouldBeTrue();
+        options.ProbeLevelsToSearch.ShouldBe(DotEnvOptions.DefaultProbeAscendLimit);
+    }
+
+    [Fact]
+    public void Constructor_WithProbeForEnvAndExplicitLevels_ShouldRespectProvidedLevel()
+    {
+        var options = new DotEnvOptions(probeForEnv: true, probeLevelsToSearch: 2, envFilePaths: null);
+        options.ProbeLevelsToSearch.ShouldBe(2);
+    }
+
+    [Fact]
     public void WithEncoding_WithNullEncoding_ShouldThrowException()
     {
         var options = new DotEnvOptions();
@@ -57,11 +72,35 @@ public class DotEnvOptionsTests
     }
 
     [Fact]
+    public void WithEnvFiles_WhenProbeForEnvIsTrue_ShouldThrow()
+    {
+        var options = new DotEnvOptions(probeForEnv: true);
+        var ex = Should.Throw<InvalidOperationException>(() => options.WithEnvFiles("custom.env"));
+        ex.Message.ShouldBe("EnvFiles paths cannot be set when ProbeForEnv is true");
+    }
+
+    [Fact]
+    public void WithEnvFiles_WithNonEmptyList_ShouldSetPaths()
+    {
+        var options = new DotEnvOptions();
+        options.WithEnvFiles("test.env");
+        options.EnvFilePaths.ShouldBe(["test.env"]);
+    }
+
+    [Fact]
     public void WithProbeForEnv_WithNegativeProbeLevels_ShouldUseDefaultProbeDepth()
     {
         var options = new DotEnvOptions();
         options.WithProbeForEnv(-1);
         options.ProbeLevelsToSearch.ShouldBe(DotEnvOptions.DefaultProbeAscendLimit);
+    }
+
+    [Fact]
+    public void WithProbeForEnv_WhenCustomEnvFilePathSet_ShouldThrow()
+    {
+        var options = new DotEnvOptions(envFilePaths: new[] { "custom.env" });
+        var ex = Should.Throw<InvalidOperationException>(() => options.WithProbeForEnv());
+        ex.Message.ShouldBe("Cannot use ProbeForEnv when EnvFiles is set.");
     }
 
     [Fact]

--- a/src/dotenv.net.Tests/DotEnvOptionsTests.cs
+++ b/src/dotenv.net.Tests/DotEnvOptionsTests.cs
@@ -31,19 +31,21 @@ public class DotEnvOptionsTests
     }
 
     [Fact]
-    public void WithEncoding_WithNullEncoding_ShouldUseUtf8()
+    public void WithEncoding_WithNullEncoding_ShouldThrowException()
     {
         var options = new DotEnvOptions();
-        options.WithEncoding(null!);
-        options.Encoding.ShouldBe(Encoding.UTF8);
+        Action action = () => options.WithEncoding(null!);
+        action.ShouldThrow<ArgumentNullException>()
+            .Message.ShouldBe("Encoding cannot be null (Parameter 'encoding')");
     }
 
     [Fact]
-    public void WithEnvFiles_WithNullParams_ShouldUseDefaultPath()
+    public void WithEnvFiles_WithNullParams_ShouldThrowException()
     {
         var options = new DotEnvOptions();
-        options.WithEnvFiles(null!);
-        options.EnvFilePaths.ShouldBe([DotEnvOptions.DefaultEnvFileName]);
+        Action action = () => options.WithEnvFiles(null!);
+        action.ShouldThrow<ArgumentNullException>()
+            .Message.ShouldBe("EnvFilePaths cannot be null (Parameter 'envFilePaths')");
     }
 
     [Fact]

--- a/src/dotenv.net.Tests/ReaderTests.cs
+++ b/src/dotenv.net.Tests/ReaderTests.cs
@@ -12,9 +12,9 @@ public class ReaderTests : IDisposable
 {
     private readonly string _tempFilePath;
     private readonly string _tempDirPath;
-    
-    private readonly string _testRootPath; // e.g., C:\Temp\TestRoot_guid\
-    private readonly string _startPath;    // e.g., C:\Temp\TestRoot_guid\level1\level2\
+
+    private readonly string _testRootPath;
+    private readonly string _startPath;
     private readonly string _originalBaseDirectory;
 
     public ReaderTests()
@@ -22,7 +22,7 @@ public class ReaderTests : IDisposable
         _tempFilePath = Path.GetTempFileName();
         _tempDirPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(_tempDirPath);
-        
+
         // Create a unique root directory for this test run in the system's temp folder.
         _testRootPath = Path.Combine(Path.GetTempPath(), "DotEnvTests_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_testRootPath);
@@ -34,7 +34,7 @@ public class ReaderTests : IDisposable
 
         // HACK: To robustly test the method without changing its source code,
         // we temporarily set the AppContext.BaseDirectory to our controlled test path.
-        _originalBaseDirectory = AppContext.GetData("APP_CONTEXT_BASE_DIRECTORY") as string;
+        _originalBaseDirectory = (string) AppContext.GetData("APP_CONTEXT_BASE_DIRECTORY")!;
         AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", _startPath);
     }
 
@@ -42,35 +42,34 @@ public class ReaderTests : IDisposable
     {
         if (File.Exists(_tempFilePath))
             File.Delete(_tempFilePath);
-            
+
         if (Directory.Exists(_tempDirPath))
             Directory.Delete(_tempDirPath, true);
-        
-        // Restore the original AppContext.BaseDirectory
+
         AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", _originalBaseDirectory);
 
-        // Clean up the temporary directory
         if (Directory.Exists(_testRootPath))
-        {
             Directory.Delete(_testRootPath, true);
-        }
     }
 
     [Theory]
     [InlineData(null, false)]
     [InlineData("", false)]
     [InlineData("   ", false)]
-    public void ReadFileLines_InvalidPathAndIgnoreExceptionsFalse_ShouldThrowArgumentException(string path, bool ignoreExceptions)
+    public void ReadFileLines_InvalidPathAndIgnoreExceptionsFalse_ShouldThrowArgumentException(string path,
+        bool ignoreExceptions)
     {
         Action act = () => Reader.ReadFileLines(path, ignoreExceptions, null);
-        act.ShouldThrow<ArgumentException>().Message.ShouldContain("The file path cannot be null, empty or whitespace.");
+        act.ShouldThrow<ArgumentException>().Message
+            .ShouldContain("The file path cannot be null, empty or whitespace.");
     }
 
     [Theory]
     [InlineData(null, true)]
     [InlineData("", true)]
     [InlineData("   ", true)]
-    public void ReadFileLines_InvalidPathAndIgnoreExceptionsTrue_ShouldReturnEmptySpan(string path, bool ignoreExceptions)
+    public void ReadFileLines_InvalidPathAndIgnoreExceptionsTrue_ShouldReturnEmptySpan(string path,
+        bool ignoreExceptions)
     {
         var result = Reader.ReadFileLines(path, ignoreExceptions, null).ToArray();
         result.ShouldBeEmpty();
@@ -81,7 +80,7 @@ public class ReaderTests : IDisposable
     {
         var path = "nonexistent.env";
         Action act = () => Reader.ReadFileLines(path, false, null);
-        act.ShouldThrow<FileNotFoundException>().Message.ShouldContain (path);
+        act.ShouldThrow<FileNotFoundException>().Message.ShouldContain(path);
     }
 
     [Fact]
@@ -137,8 +136,12 @@ public class ReaderTests : IDisposable
     [Fact]
     public void MergeEnvKeyValues_SingleArray_ShouldReturnAllItems()
     {
-        var input = new[] {
-            new[] { new KeyValuePair<string, string>("KEY1", "value1"), new KeyValuePair<string, string>("KEY2", "value2") }
+        var input = new[]
+        {
+            new[]
+            {
+                new KeyValuePair<string, string>("KEY1", "value1"), new KeyValuePair<string, string>("KEY2", "value2")
+            }
         };
         var result = Reader.MergeEnvKeyValues(input, false);
         result.ShouldBe(new Dictionary<string, string> { { "KEY1", "value1" }, { "KEY2", "value2" } });
@@ -147,7 +150,8 @@ public class ReaderTests : IDisposable
     [Fact]
     public void MergeEnvKeyValues_MultipleArraysWithoutOverwrite_ShouldKeepFirstValue()
     {
-        var input = new[] {
+        var input = new[]
+        {
             new[] { new KeyValuePair<string, string>("KEY", "first") },
             new[] { new KeyValuePair<string, string>("KEY", "second") }
         };
@@ -159,7 +163,8 @@ public class ReaderTests : IDisposable
     [Fact]
     public void MergeEnvKeyValues_MultipleArraysWithOverwrite_ShouldKeepLastValue()
     {
-        var input = new[] {
+        var input = new[]
+        {
             new[] { new KeyValuePair<string, string>("KEY", "first") },
             new[] { new KeyValuePair<string, string>("KEY", "second") }
         };
@@ -171,18 +176,22 @@ public class ReaderTests : IDisposable
     [Fact]
     public void MergeEnvKeyValues_ComplexMerge_ShouldHandleAllCases()
     {
-        var input = new[] {
-            new[] {
+        var input = new[]
+        {
+            new[]
+            {
                 new KeyValuePair<string, string>("KEY1", "value1"),
                 new KeyValuePair<string, string>("KEY2", "value2")
             },
-            new[] {
+            new[]
+            {
                 new KeyValuePair<string, string>("KEY2", "updated"),
                 new KeyValuePair<string, string>("KEY3", "value3")
             }
         };
         var result = Reader.MergeEnvKeyValues(input, true);
-        result.ShouldBe(new Dictionary<string, string> { { "KEY1", "value1" }, { "KEY2", "updated" }, { "KEY3", "value3" } });
+        result.ShouldBe(new Dictionary<string, string>
+            { { "KEY1", "value1" }, { "KEY2", "updated" }, { "KEY3", "value3" } });
     }
 
     [Fact]
@@ -192,97 +201,15 @@ public class ReaderTests : IDisposable
         act.ShouldThrow<FileNotFoundException>()
             .Message.ShouldContain(DotEnvOptions.DefaultEnvFileName);
     }
-    
-    private const string EnvFileName = ".env";
 
-    // [Fact]
-    // public void GetProbedEnvPath_ShouldReturnPath_WhenEnvFileExistsInBaseDirectory()
-    // {
-    //     var tempDir = CreateTempDirectory();
-    //     var envFilePath = Path.Combine(tempDir, EnvFileName);
-    //     File.WriteAllText(envFilePath, "KEY=VALUE");
-    //     var baseDir = AppContext.BaseDirectory;
-    //     SetAppContextBaseDirectory(tempDir);
-    //
-    //     try
-    //     {
-    //         var result = Reader.GetProbedEnvPath(3, ignoreExceptions: false).ToList();
-    //         result.Count.ShouldBe(1);
-    //         result[0].ShouldBe(envFilePath);
-    //     }
-    //     finally
-    //     {
-    //         SetAppContextBaseDirectory(baseDir);
-    //         Directory.Delete(tempDir, recursive: true);
-    //     }
-    // }
-    //
-    // [Fact]
-    // public void GetProbedEnvPath_ShouldThrowFileNotFound_WhenFileNotFoundAndIgnoreExceptionsFalse()
-    // {
-    //     var tempDir = CreateTempDirectory();
-    //     var baseDir = AppContext.BaseDirectory;
-    //     SetAppContextBaseDirectory(tempDir);
-    //
-    //     try
-    //     {
-    //         var ex = Should.Throw<FileNotFoundException>(() =>
-    //             Reader.GetProbedEnvPath(2, ignoreExceptions: false).ToList());
-    //
-    //         ex.Message.ShouldContain("Could not find");
-    //         ex.Message.ShouldContain(EnvFileName);
-    //     }
-    //     finally
-    //     {
-    //         SetAppContextBaseDirectory(baseDir);
-    //         Directory.Delete(tempDir, recursive: true);
-    //     }
-    // }
-    //
-    // [Fact]
-    // public void GetProbedEnvPath_ShouldReturnEmpty_WhenFileNotFoundAndIgnoreExceptionsTrue()
-    // {
-    //     var tempDir = CreateTempDirectory();
-    //     var baseDir = AppContext.BaseDirectory;
-    //     SetAppContextBaseDirectory(tempDir);
-    //
-    //     try
-    //     {
-    //         var result = Reader.GetProbedEnvPath(5, ignoreExceptions: true).ToList();
-    //         result.ShouldBeEmpty();
-    //     }
-    //     finally
-    //     {
-    //         SetAppContextBaseDirectory(baseDir);
-    //         Directory.Delete(tempDir, recursive: true);
-    //     }
-    // }
-    //
-    // private static string CreateTempDirectory()
-    // {
-    //     var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-    //     Directory.CreateDirectory(path);
-    //     return path;
-    // }
-    //
-    // private static void SetAppContextBaseDirectory(string path)
-    // {
-    //     typeof(AppContext)
-    //         .GetProperty("BaseDirectory")!
-    //         .SetValue(null, path);
-    // }
-    
     [Fact]
     public void GetProbedEnvPath_ShouldFindFile_InCurrentDirectory()
     {
-        // Arrange
-        var expectedPath = Path.Combine(_startPath, EnvFileName);
+        var expectedPath = Path.Combine(_startPath, DotEnvOptions.DefaultEnvFileName);
         CreateEnvFileAt(_startPath);
 
-        // Act
-        var result = Reader.GetProbedEnvPath(levelsToSearch: 0, ignoreExceptions: true);
+        var result = Reader.GetProbedEnvPath(levelsToSearch: 0, ignoreExceptions: true).ToList();
 
-        // Assert
         result.ShouldHaveSingleItem();
         result.First().ShouldBe(expectedPath);
     }
@@ -290,15 +217,12 @@ public class ReaderTests : IDisposable
     [Fact]
     public void GetProbedEnvPath_ShouldFindFile_InParentDirectory()
     {
-        // Arrange
         var parentDirectory = Directory.GetParent(_startPath)!.FullName;
-        var expectedPath = Path.Combine(parentDirectory, EnvFileName);
+        var expectedPath = Path.Combine(parentDirectory, DotEnvOptions.DefaultEnvFileName);
         CreateEnvFileAt(parentDirectory);
 
-        // Act
-        var result = Reader.GetProbedEnvPath(levelsToSearch: 1, ignoreExceptions: true);
+        var result = Reader.GetProbedEnvPath(levelsToSearch: 1, ignoreExceptions: true).ToList();
 
-        // Assert
         result.ShouldHaveSingleItem();
         result.First().ShouldBe(expectedPath);
     }
@@ -306,16 +230,12 @@ public class ReaderTests : IDisposable
     [Fact]
     public void GetProbedEnvPath_ShouldFindFile_TwoLevelsUp()
     {
-        // Arrange
         var grandParentDirectory = Directory.GetParent(_startPath)!.Parent!.FullName;
-        var expectedPath = Path.Combine(grandParentDirectory, EnvFileName);
+        var expectedPath = Path.Combine(grandParentDirectory, DotEnvOptions.DefaultEnvFileName);
         CreateEnvFileAt(grandParentDirectory);
 
-        // Act
-        // We need to search 2 levels up (level2 -> level1 -> TestRoot)
-        var result = Reader.GetProbedEnvPath(levelsToSearch: 2, ignoreExceptions: true);
+        var result = Reader.GetProbedEnvPath(levelsToSearch: 2, ignoreExceptions: true).ToList();
 
-        // Assert
         result.ShouldHaveSingleItem();
         result.First().ShouldBe(expectedPath);
     }
@@ -323,74 +243,58 @@ public class ReaderTests : IDisposable
     [Fact]
     public void GetProbedEnvPath_ShouldReturnEmpty_WhenFileNotFoundAndExceptionsIgnored()
     {
-        // Arrange
-        // No .env file is created.
-
-        // Act
         var result = Reader.GetProbedEnvPath(levelsToSearch: 3, ignoreExceptions: true);
-
-        // Assert
         result.ShouldBeEmpty();
     }
 
     [Fact]
     public void GetProbedEnvPath_ShouldThrow_WhenFileNotFoundAndExceptionsNotIgnored()
     {
-        // Arrange
         // No .env file is created.
         var levelsToSearch = 2;
         var parentPath = Directory.GetParent(_startPath)!.FullName;
         var grandParentPath = Directory.GetParent(parentPath)!.FullName;
 
-        // Act & Assert
         var exception = Should.Throw<FileNotFoundException>(() =>
         {
             Reader.GetProbedEnvPath(levelsToSearch, ignoreExceptions: false);
         });
 
-        // Assert exception message details
-        exception.Message.ShouldContain($"Could not find '{EnvFileName}'");
+        exception.Message.ShouldContain($"Could not find '{DotEnvOptions.DefaultEnvFileName}'");
         exception.Message.ShouldContain($"after searching {levelsToSearch} directory level(s) upwards.");
         exception.Message.ShouldContain("Searched paths:");
-        exception.Message.ShouldContain(_startPath);       // Searched level 0
-        exception.Message.ShouldContain(parentPath);        // Searched level 1
-        exception.Message.ShouldContain(grandParentPath);   // Searched level 2
+        exception.Message.ShouldContain(_startPath);      // Searched level 0
+        exception.Message.ShouldContain(parentPath);      // Searched level 1
+        exception.Message.ShouldContain(grandParentPath); // Searched level 2
     }
 
     [Fact]
     public void GetProbedEnvPath_ShouldReturnEmpty_WhenFileExistsButIsOutOfSearchRange()
     {
-        // Arrange
         // File is at level 2, but we only search up to level 1.
         var grandParentDirectory = Directory.GetParent(_startPath)!.Parent!.FullName;
         CreateEnvFileAt(grandParentDirectory);
 
-        // Act
         var result = Reader.GetProbedEnvPath(levelsToSearch: 1, ignoreExceptions: true);
 
-        // Assert
         result.ShouldBeEmpty();
     }
 
     [Fact]
     public void GetProbedEnvPath_ShouldThrow_WhenFileExistsButIsOutOfSearchRange()
     {
-        // Arrange
         // File is at level 2, but we only search up to level 1.
         var grandParentDirectory = Directory.GetParent(_startPath)!.Parent!.FullName;
         CreateEnvFileAt(grandParentDirectory);
 
-        // Act & Assert
         var exception = Should.Throw<FileNotFoundException>(() =>
         {
             Reader.GetProbedEnvPath(levelsToSearch: 1, ignoreExceptions: false);
         });
 
-        exception.Message.ShouldContain($"Could not find '{EnvFileName}'");
+        exception.Message.ShouldContain($"Could not find '{DotEnvOptions.DefaultEnvFileName}'");
     }
-    
-    private void CreateEnvFileAt(string directoryPath)
-    {
-        File.WriteAllText(Path.Combine(directoryPath, EnvFileName), "TEST=true");
-    }
+
+    private void CreateEnvFileAt(string directoryPath) =>
+        File.WriteAllText(Path.Combine(directoryPath, DotEnvOptions.DefaultEnvFileName), "TEST=true");
 }

--- a/src/dotenv.net.Tests/ReaderTests.cs
+++ b/src/dotenv.net.Tests/ReaderTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Shouldly;
 using Xunit;
@@ -11,12 +12,30 @@ public class ReaderTests : IDisposable
 {
     private readonly string _tempFilePath;
     private readonly string _tempDirPath;
+    
+    private readonly string _testRootPath; // e.g., C:\Temp\TestRoot_guid\
+    private readonly string _startPath;    // e.g., C:\Temp\TestRoot_guid\level1\level2\
+    private readonly string _originalBaseDirectory;
 
     public ReaderTests()
     {
         _tempFilePath = Path.GetTempFileName();
         _tempDirPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(_tempDirPath);
+        
+        // Create a unique root directory for this test run in the system's temp folder.
+        _testRootPath = Path.Combine(Path.GetTempPath(), "DotEnvTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_testRootPath);
+
+        // Create a nested structure to simulate parent directories.
+        // StartPath will be our simulated AppContext.BaseDirectory.
+        _startPath = Path.Combine(_testRootPath, "level1", "level2");
+        Directory.CreateDirectory(_startPath);
+
+        // HACK: To robustly test the method without changing its source code,
+        // we temporarily set the AppContext.BaseDirectory to our controlled test path.
+        _originalBaseDirectory = AppContext.GetData("APP_CONTEXT_BASE_DIRECTORY") as string;
+        AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", _startPath);
     }
 
     public void Dispose()
@@ -26,6 +45,15 @@ public class ReaderTests : IDisposable
             
         if (Directory.Exists(_tempDirPath))
             Directory.Delete(_tempDirPath, true);
+        
+        // Restore the original AppContext.BaseDirectory
+        AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", _originalBaseDirectory);
+
+        // Clean up the temporary directory
+        if (Directory.Exists(_testRootPath))
+        {
+            Directory.Delete(_testRootPath, true);
+        }
     }
 
     [Theory]
@@ -160,43 +188,209 @@ public class ReaderTests : IDisposable
     [Fact]
     public void GetProbedEnvPath_FileNotFoundAndIgnoreExceptionsFalse_ShouldThrow()
     {
-        using var dir = new TempWorkingDirectory(_tempDirPath);
         Action act = () => Reader.GetProbedEnvPath(levelsToSearch: 2, ignoreExceptions: false);
         act.ShouldThrow<FileNotFoundException>()
             .Message.ShouldContain(DotEnvOptions.DefaultEnvFileName);
     }
+    
+    private const string EnvFileName = ".env";
 
+    // [Fact]
+    // public void GetProbedEnvPath_ShouldReturnPath_WhenEnvFileExistsInBaseDirectory()
+    // {
+    //     var tempDir = CreateTempDirectory();
+    //     var envFilePath = Path.Combine(tempDir, EnvFileName);
+    //     File.WriteAllText(envFilePath, "KEY=VALUE");
+    //     var baseDir = AppContext.BaseDirectory;
+    //     SetAppContextBaseDirectory(tempDir);
+    //
+    //     try
+    //     {
+    //         var result = Reader.GetProbedEnvPath(3, ignoreExceptions: false).ToList();
+    //         result.Count.ShouldBe(1);
+    //         result[0].ShouldBe(envFilePath);
+    //     }
+    //     finally
+    //     {
+    //         SetAppContextBaseDirectory(baseDir);
+    //         Directory.Delete(tempDir, recursive: true);
+    //     }
+    // }
+    //
+    // [Fact]
+    // public void GetProbedEnvPath_ShouldThrowFileNotFound_WhenFileNotFoundAndIgnoreExceptionsFalse()
+    // {
+    //     var tempDir = CreateTempDirectory();
+    //     var baseDir = AppContext.BaseDirectory;
+    //     SetAppContextBaseDirectory(tempDir);
+    //
+    //     try
+    //     {
+    //         var ex = Should.Throw<FileNotFoundException>(() =>
+    //             Reader.GetProbedEnvPath(2, ignoreExceptions: false).ToList());
+    //
+    //         ex.Message.ShouldContain("Could not find");
+    //         ex.Message.ShouldContain(EnvFileName);
+    //     }
+    //     finally
+    //     {
+    //         SetAppContextBaseDirectory(baseDir);
+    //         Directory.Delete(tempDir, recursive: true);
+    //     }
+    // }
+    //
+    // [Fact]
+    // public void GetProbedEnvPath_ShouldReturnEmpty_WhenFileNotFoundAndIgnoreExceptionsTrue()
+    // {
+    //     var tempDir = CreateTempDirectory();
+    //     var baseDir = AppContext.BaseDirectory;
+    //     SetAppContextBaseDirectory(tempDir);
+    //
+    //     try
+    //     {
+    //         var result = Reader.GetProbedEnvPath(5, ignoreExceptions: true).ToList();
+    //         result.ShouldBeEmpty();
+    //     }
+    //     finally
+    //     {
+    //         SetAppContextBaseDirectory(baseDir);
+    //         Directory.Delete(tempDir, recursive: true);
+    //     }
+    // }
+    //
+    // private static string CreateTempDirectory()
+    // {
+    //     var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+    //     Directory.CreateDirectory(path);
+    //     return path;
+    // }
+    //
+    // private static void SetAppContextBaseDirectory(string path)
+    // {
+    //     typeof(AppContext)
+    //         .GetProperty("BaseDirectory")!
+    //         .SetValue(null, path);
+    // }
+    
     [Fact]
-    public void GetProbedEnvPath_FileNotFoundAndIgnoreExceptionsTrue_ShouldReturnNull()
+    public void GetProbedEnvPath_ShouldFindFile_InCurrentDirectory()
     {
-        using var dir = new TempWorkingDirectory(_tempDirPath);
-        var result = Reader.GetProbedEnvPath(levelsToSearch: 2, ignoreExceptions: true);
-        result.ShouldBeNull();
+        // Arrange
+        var expectedPath = Path.Combine(_startPath, EnvFileName);
+        CreateEnvFileAt(_startPath);
+
+        // Act
+        var result = Reader.GetProbedEnvPath(levelsToSearch: 0, ignoreExceptions: true);
+
+        // Assert
+        result.ShouldHaveSingleItem();
+        result.First().ShouldBe(expectedPath);
     }
 
     [Fact]
-    public void GetProbedEnvPath_LevelsTooLow_ShouldNotFindFile()
+    public void GetProbedEnvPath_ShouldFindFile_InParentDirectory()
     {
-        var envPath = Path.Combine(_tempDirPath, ".env");
-        File.WriteAllText(envPath, "TEST=value");
-        var startDir = Path.Combine(_tempDirPath, "subdir1", "subdir2", "subdir3");
-        Directory.CreateDirectory(startDir);
+        // Arrange
+        var parentDirectory = Directory.GetParent(_startPath)!.FullName;
+        var expectedPath = Path.Combine(parentDirectory, EnvFileName);
+        CreateEnvFileAt(parentDirectory);
 
-        using var dir = new TempWorkingDirectory(startDir);
-        var result = Reader.GetProbedEnvPath(levelsToSearch: 2, ignoreExceptions: true);
-        result.ShouldBeNull();
+        // Act
+        var result = Reader.GetProbedEnvPath(levelsToSearch: 1, ignoreExceptions: true);
+
+        // Assert
+        result.ShouldHaveSingleItem();
+        result.First().ShouldBe(expectedPath);
     }
 
-    private class TempWorkingDirectory : IDisposable
+    [Fact]
+    public void GetProbedEnvPath_ShouldFindFile_TwoLevelsUp()
     {
-        private readonly string _originalDirectory;
+        // Arrange
+        var grandParentDirectory = Directory.GetParent(_startPath)!.Parent!.FullName;
+        var expectedPath = Path.Combine(grandParentDirectory, EnvFileName);
+        CreateEnvFileAt(grandParentDirectory);
 
-        public TempWorkingDirectory(string path)
+        // Act
+        // We need to search 2 levels up (level2 -> level1 -> TestRoot)
+        var result = Reader.GetProbedEnvPath(levelsToSearch: 2, ignoreExceptions: true);
+
+        // Assert
+        result.ShouldHaveSingleItem();
+        result.First().ShouldBe(expectedPath);
+    }
+
+    [Fact]
+    public void GetProbedEnvPath_ShouldReturnEmpty_WhenFileNotFoundAndExceptionsIgnored()
+    {
+        // Arrange
+        // No .env file is created.
+
+        // Act
+        var result = Reader.GetProbedEnvPath(levelsToSearch: 3, ignoreExceptions: true);
+
+        // Assert
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetProbedEnvPath_ShouldThrow_WhenFileNotFoundAndExceptionsNotIgnored()
+    {
+        // Arrange
+        // No .env file is created.
+        var levelsToSearch = 2;
+        var parentPath = Directory.GetParent(_startPath)!.FullName;
+        var grandParentPath = Directory.GetParent(parentPath)!.FullName;
+
+        // Act & Assert
+        var exception = Should.Throw<FileNotFoundException>(() =>
         {
-            _originalDirectory = Directory.GetCurrentDirectory();
-            Directory.SetCurrentDirectory(path);
-        }
+            Reader.GetProbedEnvPath(levelsToSearch, ignoreExceptions: false);
+        });
 
-        public void Dispose() => Directory.SetCurrentDirectory(_originalDirectory);
+        // Assert exception message details
+        exception.Message.ShouldContain($"Could not find '{EnvFileName}'");
+        exception.Message.ShouldContain($"after searching {levelsToSearch} directory level(s) upwards.");
+        exception.Message.ShouldContain("Searched paths:");
+        exception.Message.ShouldContain(_startPath);       // Searched level 0
+        exception.Message.ShouldContain(parentPath);        // Searched level 1
+        exception.Message.ShouldContain(grandParentPath);   // Searched level 2
+    }
+
+    [Fact]
+    public void GetProbedEnvPath_ShouldReturnEmpty_WhenFileExistsButIsOutOfSearchRange()
+    {
+        // Arrange
+        // File is at level 2, but we only search up to level 1.
+        var grandParentDirectory = Directory.GetParent(_startPath)!.Parent!.FullName;
+        CreateEnvFileAt(grandParentDirectory);
+
+        // Act
+        var result = Reader.GetProbedEnvPath(levelsToSearch: 1, ignoreExceptions: true);
+
+        // Assert
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetProbedEnvPath_ShouldThrow_WhenFileExistsButIsOutOfSearchRange()
+    {
+        // Arrange
+        // File is at level 2, but we only search up to level 1.
+        var grandParentDirectory = Directory.GetParent(_startPath)!.Parent!.FullName;
+        CreateEnvFileAt(grandParentDirectory);
+
+        // Act & Assert
+        var exception = Should.Throw<FileNotFoundException>(() =>
+        {
+            Reader.GetProbedEnvPath(levelsToSearch: 1, ignoreExceptions: false);
+        });
+
+        exception.Message.ShouldContain($"Could not find '{EnvFileName}'");
+    }
+    
+    private void CreateEnvFileAt(string directoryPath)
+    {
+        File.WriteAllText(Path.Combine(directoryPath, EnvFileName), "TEST=true");
     }
 }

--- a/src/dotenv.net.Tests/ReaderTests.cs
+++ b/src/dotenv.net.Tests/ReaderTests.cs
@@ -11,7 +11,6 @@ namespace dotenv.net.Tests;
 public class ReaderTests : IDisposable
 {
     private readonly string _tempFilePath;
-    private readonly string _tempDirPath;
 
     private readonly string _testRootPath;
     private readonly string _startPath;
@@ -20,8 +19,6 @@ public class ReaderTests : IDisposable
     public ReaderTests()
     {
         _tempFilePath = Path.GetTempFileName();
-        _tempDirPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(_tempDirPath);
 
         // Create a unique root directory for this test run in the system's temp folder.
         _testRootPath = Path.Combine(Path.GetTempPath(), "DotEnvTests_" + Guid.NewGuid().ToString("N"));
@@ -42,9 +39,6 @@ public class ReaderTests : IDisposable
     {
         if (File.Exists(_tempFilePath))
             File.Delete(_tempFilePath);
-
-        if (Directory.Exists(_tempDirPath))
-            Directory.Delete(_tempDirPath, true);
 
         AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", _originalBaseDirectory);
 

--- a/src/dotenv.net/DotEnv.cs
+++ b/src/dotenv.net/DotEnv.cs
@@ -19,7 +19,7 @@ public static class DotEnv
     {
         options ??= new DotEnvOptions();
         var envFilePaths = options.ProbeForEnv
-            ? [Reader.GetProbedEnvPath(options.ProbeLevelsToSearch, options.IgnoreExceptions)]
+            ? Reader.GetProbedEnvPath(options.ProbeLevelsToSearch!.Value, options.IgnoreExceptions)
             : options.EnvFilePaths;
         var envFileKeyValues = envFilePaths
             .Select(envFilePath =>

--- a/src/dotenv.net/DotEnvOptions.cs
+++ b/src/dotenv.net/DotEnvOptions.cs
@@ -177,7 +177,7 @@ public class DotEnvOptions
     public DotEnvOptions WithEncoding(Encoding encoding)
     {
         if (encoding == null ) 
-            throw new ArgumentNullException(nameof(encoding));
+            throw new ArgumentNullException(nameof(encoding), "Encoding cannot be null");
 
         Encoding = encoding;
         return this;
@@ -191,6 +191,9 @@ public class DotEnvOptions
     {
         if (ProbeForEnv)
             throw new InvalidOperationException("EnvFiles paths cannot be set when ProbeForEnv is true");
+
+        if (envFilePaths == null ) 
+            throw new ArgumentNullException(nameof(envFilePaths), "EnvFilePaths cannot be null");
 
         EnvFilePaths = envFilePaths.Any() != true ? DefaultEnvPath : envFilePaths;
         return this;

--- a/src/dotenv.net/DotEnvOptions.cs
+++ b/src/dotenv.net/DotEnvOptions.cs
@@ -176,6 +176,9 @@ public class DotEnvOptions
     /// <returns>configured dot env options</returns>
     public DotEnvOptions WithEncoding(Encoding encoding)
     {
+        if (encoding == null ) 
+            throw new ArgumentNullException(nameof(encoding));
+
         Encoding = encoding;
         return this;
     }

--- a/src/dotenv.net/Reader.cs
+++ b/src/dotenv.net/Reader.cs
@@ -76,7 +76,7 @@ internal static class Reader
             {
                 pathsSearched.Add(directory.FullName);
 
-                foreach (var fileInfo in directory.GetFiles(DotEnvOptions.DefaultEnvFileName, SearchOption.TopDirectoryOnly)) 
+                foreach (var fileInfo in directory.EnumerateFiles(DotEnvOptions.DefaultEnvFileName, SearchOption.TopDirectoryOnly)) 
                     return fileInfo.FullName;
                 
                 directory = directory.Parent;

--- a/src/dotenv.net/Reader.cs
+++ b/src/dotenv.net/Reader.cs
@@ -67,18 +67,23 @@ internal static class Reader
             throw new FileNotFoundException(
                 $"Could not find '{DotEnvOptions.DefaultEnvFileName}' after searching {levelsToSearch} directory level(s) upwards.{Environment.NewLine}Searched paths:{Environment.NewLine}{string.Join(Environment.NewLine, pathsSearched)}");
 
-        return foundEnvPath == null ? []: [foundEnvPath];
+        return foundEnvPath == null ? [] : [foundEnvPath];
 
         string? SearchPaths()
         {
-            var directory =  new DirectoryInfo(AppContext.BaseDirectory);
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
             for (var i = 0; i <= count; i++)
             {
+                if (directory == null)
+                    break;
+
                 pathsSearched.Add(directory.FullName);
 
-                foreach (var fileInfo in directory.EnumerateFiles(DotEnvOptions.DefaultEnvFileName, SearchOption.TopDirectoryOnly)) 
+                foreach (var fileInfo in directory.EnumerateFiles(DotEnvOptions.DefaultEnvFileName,
+                             SearchOption.TopDirectoryOnly))
                     return fileInfo.FullName;
-                
+
                 directory = directory.Parent;
             }
 


### PR DESCRIPTION
This PR fixes the issue described in #56  where the path reported in the exception message is wrong. It also introduces more detailed exception messages with a list of paths searched to improve debugging