### PR TITLE
docs: add XML code usage examples for DotEnvOptions fluent methods

### DIFF
--- a/src/dotenv.net/DotEnv.cs
+++ b/src/dotenv.net/DotEnv.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace dotenv.net;
@@ -19,6 +19,12 @@ public static class DotEnv
     /// </summary>
     /// <param name="options">The options required to configure the env loader. If null, default options are used.</param>
     /// <returns>A dictionary containing the key-value pairs read from the env files.</returns>
+    /// <example>
+    /// <code>
+    /// var envVars = DotEnv.Read();
+    /// Console.WriteLine(envVars["DATABASE_URL"]);
+    /// </code>
+    /// </example>
     public static IDictionary<string, string> Read(DotEnvOptions? options = null)
     {
         options ??= new DotEnvOptions();
@@ -61,6 +67,11 @@ public static class DotEnv
     /// Loads the values from the provided env files into the system environment variables.
     /// </summary>
     /// <param name="options">The options required to configure the env loader. If null, default options are used.</param>
+    /// <example>
+    /// <code>
+    /// DotEnv.Load();
+    /// </code>
+    /// </example>
     public static void Load(DotEnvOptions? options = null)
     {
         options ??= new DotEnvOptions();

--- a/src/dotenv.net/DotEnvOptions.cs
+++ b/src/dotenv.net/DotEnvOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -114,6 +114,11 @@ public class DotEnvOptions
     /// Enables exception throwing when errors occur.
     /// </summary>
     /// <returns>The current <see cref="DotEnvOptions"/> instance.</returns>
+    /// <example>
+    /// <code>
+    /// DotEnv.Fluent().WithExceptions().Load();
+    /// </code>
+    /// </example>
     public DotEnvOptions WithExceptions()
     {
         IgnoreExceptions = false;
@@ -136,6 +141,11 @@ public class DotEnvOptions
     /// <param name="probeLevelsToSearch">How high up the directory chain to search.</param>
     /// <returns>The current <see cref="DotEnvOptions"/> instance.</returns>
     /// <exception cref="InvalidOperationException">Thrown when EnvFiles is already set.</exception>
+    /// <example>
+    /// <code>
+    /// DotEnv.Fluent().WithProbeForEnv(probeLevelsToSearch: 4).Load();
+    /// </code>
+    /// </example>
     public DotEnvOptions WithProbeForEnv(int probeLevelsToSearch = DefaultProbeAscendLimit)
     {
         if (EnvFilePaths?.FirstOrDefault() != DefaultEnvFileName)


### PR DESCRIPTION
### Summary
Adds XML `<example>` code blocks to `WithExceptions` and `WithProbeForEnv` in `DotEnvOptions.cs` to show quick IntelliSense code usage.